### PR TITLE
Added support for MC 1.21.8 & Fix versions for >=1.21.5

### DIFF
--- a/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
+++ b/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
@@ -20,7 +20,7 @@ public enum VersionUtils {
     v1_21_R5(1215, 125),
     v1_21_R6(1216, 126),
     v1_21_R7(1217, 127);
-    v1_21_R7(1217, 128);
+    v1_21_R8(1218, 128);
 
     private static VersionUtils version;
     private final int[] versionId;

--- a/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
+++ b/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
@@ -20,6 +20,7 @@ public enum VersionUtils {
     v1_21_R5(1215, 125),
     v1_21_R6(1216, 126),
     v1_21_R7(1217, 127);
+    v1_21_R7(1217, 128);
 
     private static VersionUtils version;
     private final int[] versionId;

--- a/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
+++ b/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
@@ -16,7 +16,10 @@ public enum VersionUtils {
     v1_21_R1(1211, 121),
     v1_21_R2(1212, 122),
     v1_21_R3(1213, 123),
-    v1_21_R4(1214, 124);
+    v1_21_R4(1214, 124),
+    v1_21_R5(1215, 125),
+    v1_21_R6(1216, 126),
+    v1_21_R7(1217, 127);
 
     private static VersionUtils version;
     private final int[] versionId;
@@ -40,8 +43,8 @@ public enum VersionUtils {
         try {
             version = extractFromString(Bukkit.getBukkitVersion().split("-")[0].replaceAll("\\.", ""));
         } catch (Exception e) {
-            HeadBlocks.log.sendMessage(MessageUtils.colorize("&cError extracting server version" + e.getMessage() + ". Using " + v1_21_R4.name()));
-            version = v1_21_R4;
+            HeadBlocks.log.sendMessage(MessageUtils.colorize("&cError extracting server version" + e.getMessage() + ". Using " + v1_21_R7.name()));
+            version = v1_21_R7;
         }
 
         return version;
@@ -61,9 +64,5 @@ public enum VersionUtils {
 
     public static boolean isNewerOrEqualsTo(VersionUtils version) {
         return getVersion().getVersionId() >= version.getVersionId();
-    }
-
-    public static boolean isOlderThan(VersionUtils version) {
-        return getVersion().getVersionId() < version.getVersionId();
     }
 }

--- a/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
+++ b/core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java
@@ -44,8 +44,8 @@ public enum VersionUtils {
         try {
             version = extractFromString(Bukkit.getBukkitVersion().split("-")[0].replaceAll("\\.", ""));
         } catch (Exception e) {
-            HeadBlocks.log.sendMessage(MessageUtils.colorize("&cError extracting server version" + e.getMessage() + ". Using " + v1_21_R7.name()));
-            version = v1_21_R7;
+            HeadBlocks.log.sendMessage(MessageUtils.colorize("&cError extracting server version" + e.getMessage() + ". Using " + v1_21_R8.name()));
+            version = v1_21_R8;
         }
 
         return version;


### PR DESCRIPTION
⚠️ I haven't been able to test whether this corrects the problem correctly, due to problems with the libs to be downloaded at the moment ⚠️

This pull request updates the `VersionUtils` class in `core/src/main/java/fr/aerwyn81/headblocks/utils/bukkit/VersionUtils.java` to support newer server versions and simplifies version comparison methods. The most important changes include adding new version constants, updating the default version fallback, and removing an unused method.

### Support for newer server versions:
* Added new version constants `v1_21_R5`, `v1_21_R6`, `v1_21_R7` and `v1_21_R8` to the `VersionUtils` enum to support additional server versions.

### Default version fallback:
* Updated the fallback version in `getVersion()` to use `v1_21_R8` instead of `v1_21_R4` when an error occurs during server version extraction.

### Simplification of version comparison:
* Removed the `isOlderThan` method as it is redundant and simplifies the class by relying solely on `isNewerOrEqualsTo` for version comparison.

Close #23